### PR TITLE
Add body tag to example html

### DIFF
--- a/examples/tailwind/index.html
+++ b/examples/tailwind/index.html
@@ -8,4 +8,6 @@
     <link data-trunk rel="copy-dir" href="images" />
     <base data-trunk-public-url />
   </head>
+  <body>
+  </body>
 </html>


### PR DESCRIPTION
Thank you for this excellent work! The example does not compile and run, and gives the following error:

```shell
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 9.41s
2024-06-04T08:06:09.593807Z ERROR ❌ error
error from build pipeline

Caused by:
    0: HTML build pipeline failed (1 errors), showing first
    1: failed to finalize asset pipeline
    2: Document has neither a <link data-trunk rel="rust"/> nor a <body>. Either one must be present.
```

Adding the body tag to `index.html` fixes the build error.